### PR TITLE
Implement update check on startup

### DIFF
--- a/src/bin/rpc.py
+++ b/src/bin/rpc.py
@@ -1,7 +1,46 @@
 import sys
 from os.path import exists, join, abspath, dirname, normcase, normpath
 from json import loads
+import os
+import ctypes
+import requests
+import webbrowser
 from src.utilities.rpc import Presence
+
+
+def check_for_update(current_version: str) -> None:
+    """Check GitHub for a new release and notify the user."""
+    try:
+        response = requests.get(
+            "https://api.github.com/repos/6uhrmittag/Synth-Riders-DiscordRPC/releases/latest",
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            tag = data.get("tag_name") or data.get("name")
+            release_url = data.get("html_url")
+            if tag:
+                latest = tag.lstrip("v")
+                if latest != current_version:
+                    message = (
+                        f"A new version ({latest}) is available. Open download page?"
+                    )
+                    if os.name == "nt":
+                        result = ctypes.windll.user32.MessageBoxW(
+                            None,
+                            message,
+                            "Update Available",
+                            1,
+                        )
+                        if result == 1 and release_url:
+                            webbrowser.open(release_url)
+                    else:
+                        print(message)
+                        if release_url:
+                            webbrowser.open(release_url)
+    except Exception:
+        # Silently ignore update check errors
+        pass
 
 config_path = join(abspath(dirname(sys.executable)), "config/config.json")
 
@@ -16,6 +55,8 @@ with open(config_path, "r") as f:
         raise Exception(
             "The rich presence install location in the config file does not match the actual install location. Please update the config file, or setup the RPC again"
         )
+
+check_for_update(config.get("version", "0"))
 
 presence = Presence(config)
 presence.start()


### PR DESCRIPTION
## Summary
- add a helper in `src/bin/rpc.py` to query GitHub releases
- notify the user when a newer version is available and open browser on confirmation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684948f9bffc832e9d63ef0e14818472